### PR TITLE
update readme to fix installation...again

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # telemetry
 
-* http://github.com/rock-core/tools-telemetry
+tools-telemetry :: http://github.com/rock-core/tools-telemetry
 
 ## DESCRIPTION:
 


### PR DESCRIPTION
to fix the following error:

```
/usr/bin/ruby3.0 -S rake default
in directory ..../.../tools/telemetry
rake aborted!
Please switch readme to hash format for urls.
...../.autoproj/gems/ruby/3.0.0/gems/hoe-4.1.0/lib/hoe.rb:730:in `parse_urls'
...../.autoproj/gems/ruby/3.0.0/gems/hoe-4.1.0/lib/hoe.rb:690:in `intuit_values'
...../.autoproj/gems/ruby/3.0.0/gems/hoe-4.1.0/lib/hoe.rb:825:in `post_initialize'
...../.autoproj/gems/ruby/3.0.0/gems/hoe-4.1.0/lib/hoe.rb:406:in `spec'
...../rock_boomstick22.04/tools/telemetry/Rakefile:9:in `<top (required)>'
...../.autoproj/gems/ruby/3.0.0/gems/rake-13.1.0/exe/rake:27:in `<top (required)>'
```